### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -122,7 +122,7 @@ class syntax_plugin_quickstats extends DokuWiki_Syntax_Plugin {
     * Handler to prepare matched data for the rendering process.
     *
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
        global $ID;
         $this->helper->writeCache($ID);
         switch ($state) {
@@ -182,7 +182,7 @@ class syntax_plugin_quickstats extends DokuWiki_Syntax_Plugin {
    /**
     * Handle the actual output creation.    
     */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
      
         if($mode == 'xhtml'){
            


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.