### PR TITLE
Trim text

### DIFF
--- a/lang/en/general_intro.txt
+++ b/lang/en/general_intro.txt
@@ -1,8 +1,8 @@
-With this admin panel you can do three things. 
+With this admin panel you can do three things.
     -  maintain the list of files which are currently using the quickstats syntax plugin, keeping it up-to-date;
-    -  make specific queries based on country, ip address, and Dokuwiki page names; 
+    -  make specific queries based on country, ip address, and Dokuwiki page names;
     - download the Maxmind GeoLiteCity.dat database into ''lib/plugins/quickstats/GEOIP/''; for this work you must set the ''geoip_local'' option to true in the Configuration Manager.
 
-For the maintenance panel, click on the **Update Quickstats Cache** button.  For the Query panel, click on the **Query Data** button. 
-These are toggles and will both open and close their respective windows.  The **Query Info** button will re-open the Query Info panel which 
+For the maintenance panel, click on the **Update Quickstats Cache** button.  For the Query panel, click on the **Query Data** button.
+These are toggles and will both open and close their respective windows.  The **Query Info** button will re-open the Query Info panel which
 is displayed on first opening the Query Data panel and which can be closed with a button at the bottom of the Query Info panel.  The **Download DB** button will attempt to download the Maxmind database.

--- a/lang/en/intro.txt
+++ b/lang/en/intro.txt
@@ -2,9 +2,5 @@ To save download time, ''quickstats'' attempts to download its table sorting scr
 use the ''quickstats'' syntax  and therefore use these scripts.  This utility will prune away any files which are no longer being used for ''quickstats''.
 Clicking on the 'Delete' button will save your deletions to memory; clicking on 'Confirm Deletion' will remove them from the cache.  There is no harm
 in removing a page from the cache file.  If it contains ''quickstats'' syntax, it will be added to the cache file the next time the page is opened in the
-editor and either previewed or changed and saved.  The change can simply be a new line.   You can also add the page to the ''sorttable_ns'' list
+editor and either previewed or changed and saved.  The change can simply be a new line.  You can also add the page to the ''sorttable_ns'' list
 in the configuration editor.
-
-
-
-

--- a/lang/en/query.txt
+++ b/lang/en/query.txt
@@ -1,26 +1,26 @@
 ===== Queries =====
-Queries can be about pages, IP addresses, Countries, or Browser/User Agents. 
+Queries can be about pages, IP addresses, Countries, or Browser/User Agents.
 
 ==== Rules ====
-Queries are governed by the dominant or **priority** field.      
-   - Any priority with country set will match the priority field plus the country.              
+Queries are governed by the dominant or **priority** field.
+   - Any priority with country set will match the priority field plus the country.
    - Page priority with both user agent and country set will match all three fields.
    - IP queries (i.e. ip priority) ignore all other fields and if an IP is included in a query where another field has priority, the IP address is ignored.
 
-You can choose to ignore all fields other than the priority field and then only the priority field will be searched.  
-   
+You can choose to ignore all fields other than the priority field and then only the priority field will be searched.
+
 ==== Searches ====
-The search functions are case-insensitive and will match partial strings as well as whole strings.  So, for instance, 
+The search functions are case-insensitive and will match partial strings as well as whole strings.  So, for instance,
 if you search for ''wiki'' in the page search, it will return all pages which occur in the wiki namespace and any other pages
 which include wiki in their names.
 
-   - **UserAgent Search:**  This search is useful if a particular user agent does not show up on the drop-down menu. This can happen if a user agent string appears in a subversion but not in the major version string.  A successful search will add whatever is found to the top of the drop-down menu so that  you can then select it.   
+   - **UserAgent Search:**  This search is useful if a particular user agent does not show up on the drop-down menu. This can happen if a user agent string appears in a subversion but not in the major version string.  A successful search will add whatever is found to the top of the drop-down menu so that  you can then select it.
    - **Country Search: **   If a country does not appear in the list of countries, this will add it to the list so that you can then select it.  If you enter a partial name, it will add all matches.  For instance, if you enter 'isl', you will add a whole list of countries that have Island in their names
-   - ** Page:**  This will accept any whole or part of a page name and will return results for all matching values.     
-  
- ==== Dates ====  
- Dates are all confined to months within the same year.   You can select multiple dates except for page priority.  However, the page
- field can be included in a multi-date query where one of the other fields has priority.
+   - ** Page:**  This will accept any whole or part of a page name and will return results for all matching values.
+
+==== Dates ====
+Dates are all confined to months within the same year.   You can select multiple dates except for page priority.  However, the page
+field can be included in a multi-date query where one of the other fields has priority.
 
 
 ==== Output ====
@@ -43,7 +43,7 @@ column will appear in tables with ''User Agent'' and ''Country'' priority.
 
 ==== File Menu ====
 
-There is a drop-down menu of files which are currently using the quickstats syntax.  You can click on these an the page will pop up.  
+There is a drop-down menu of files which are currently using the quickstats syntax.  You can click on these an the page will pop up.
 This serves a two-fold purpose: \\
 1. They give you a convenient means of checking names and IP's which you might want to use in your queries. \\
 2. They enable you to keep all your work with quickstats in the admin panel, giving you immediate access to any


### PR DESCRIPTION
This PR removes spaces from english text files. The texts are not otherwise modified.

Just because the leading and trailing spaces are really
annoying on translate.dokuwiki.org.